### PR TITLE
Get it working in Firefox, too!  😃

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+node_modules/
+dest/

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,32 @@
+'use strict';
+
+var gulp = require('gulp');
+var jeditor = require('gulp-json-editor');
+var merge = require('merge-stream');
+var zip = require('gulp-zip');
+
+var xpiName = 'github-canned-responses.xpi';
+var zipName = 'github-canned-responses.zip';
+
+gulp.task('default', function () {
+  var files = ['src/*', '!src/manifest.json'];
+  var manifest = gulp.src('src/manifest.json');
+  var dest = gulp.dest('dest/');
+
+  merge(gulp.src(files), manifest)
+    .pipe(zip(zipName))
+    .pipe(dest);
+
+  manifest = manifest.pipe(jeditor({
+    'applications': {
+      'gecko': {
+        'id': 'github-canned-responses@example',
+        'strict_min_version': '43.0.0'
+      }
+    }
+  }));
+
+  merge(gulp.src(files), manifest)
+    .pipe(zip(xpiName))
+    .pipe(dest);
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "github-canned-responses",
+  "version": "1.0.5",
+  "description": "Choose from a set of canned responses when commenting on your GitHub PRs or issues",
+  "main": "background.js",
+  "dependencies": {
+    "gulp": "^3.9.0",
+    "gulp-json-editor": "^2.2.1",
+    "gulp-zip": "^3.1.0",
+    "merge-stream": "^1.0.0"
+  },
+  "devDependencies": {},
+  "scripts": {
+    "build": "gulp"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/notwaldorf/github-canned-responses.git"
+  },
+  "author": "Monica Dinculescu",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/notwaldorf/github-canned-responses/issues"
+  },
+  "homepage": "https://github.com/notwaldorf/github-canned-responses#readme"
+}


### PR DESCRIPTION
That was easy…

Tested in Firefox nightly.
![firefox canned responses](https://dl.dropboxusercontent.com/u/2301433/Firefox/WebExtensions/github-canned-responses.png)
Downloadable from [here](https://dl.dropboxusercontent.com/u/2301433/Firefox/WebExtensions/github-canned-responses.xpi).
