### PR TITLE
Possibly work around a bug in addons.mozilla.org.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -20,8 +20,7 @@ gulp.task('default', function () {
   manifest = manifest.pipe(jeditor({
     'applications': {
       'gecko': {
-        'id': 'github-canned-responses@example',
-        'strict_min_version': '43.0.0'
+        'id': 'github-canned-responses@example'
       }
     }
   }));


### PR DESCRIPTION
I'm not sure why the strict_min_version causes mozilla/addons#26 but it seems to work without it, so maybe we don't want it in there?
