### PR TITLE
options.html: minor hygiene.

### DIFF
--- a/src/options.html
+++ b/src/options.html
@@ -1,10 +1,10 @@
 <!doctype html>
 <html>
 <head>
-  <meta http-equiv="content-type" content="text/html; charset=utf-8">
+  <meta charset="utf-8">
   <title>Canned response settings</title>
-  <link href='http://fonts.googleapis.com/css?family=Lato:300,400,700' rel='stylesheet' type='text/css'>
-  <link href='options.css' rel='stylesheet' type='text/css'>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato:300,400,700">
+  <link rel="stylesheet" href="options.css">
   <style>
     body {
       font-family: 'Lato';


### PR DESCRIPTION
- remove default type for `link`
- use `https` for Google fonts
- use `meta charset`
