### PR TITLE
Change allowed paths regex to support repos that have `.` in the org/…

### DIFF
--- a/src/contentScript.js
+++ b/src/contentScript.js
@@ -7,13 +7,13 @@ var __gcrExtAnswers;
   // https://github.com/thieman/github-selfies/blob/master/chrome/selfie.js
   var allowedPaths = [
     // New issues
-    /github.com\/[\w\-]+\/[\w\-]+\/issues\/new/,
+    /github.com\/[\w-.]+\/[\w-.]+\/issues\/new/,
     // Existing issues (comment)
-    /github.com\/[\w\-]+\/[\w\-]+\/issues\/\d+/,
+    /github.com\/[\w-.]+\/[\w-.]+\/issues\/\d+/,
     // New pull request
-    /github.com\/[\w\-]+\/[\w\-]+\/compare/,
+    /github.com\/[\w-.]+\/[\w-.]+\/compare/,
     // Existing pull requests (comment)
-    /github.com\/[\w\-]+\/[\w\-]+\/pull\/\d+/
+    /github.com\/[\w-.]+\/[\w-.]+\/pull\/\d+/
   ];
 
   // Inject the code from fn into the page, in an IIFE.


### PR DESCRIPTION
…repo

This is awesome!

The current regex doesn't seem to support repos that have a `.` in the name like a website repo: https://github.com/babel/babel.github.io/pull/746

I just added `.` to the regexes, and removed the `\` from `\-` since it isn't needed when using `[]`

(I'm doing a similar regex in a extension I started [here](https://github.com/hzoo/github-contributor-extension/blob/e54a08ba60c620a2e65579ef8af9c83328133fe9/src/background.js#L12).

---

Tested locally (repo with `-_.`)

<img width="672" alt="screen shot 2016-03-05 at 3 12 03 pm" src="https://cloud.githubusercontent.com/assets/588473/13550144/b10fb896-e2e4-11e5-8d4a-f5595b02af05.png">
