### PR TITLE
Update README.md with link to GitHub's Saved replies feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-#🚨🚨🚨 This repo is unmaintained!
-Hai! Thanks for stopping by! Since GitHub shipped a similar feature for realsies, there's no real point for me to maintain this extension. I've had requests from a couple of people not to nuke this repo since they'd still like to use this, so feel free to continue using it. Or not. It's really up to you. Here's a cactus :cactus: 
+# 🚨🚨🚨 This repo is unmaintained! 🚨🚨🚨
+Hai! Thanks for stopping by! Since GitHub shipped a similar feature for realsies, [Saved replies](https://help.github.com/articles/working-with-saved-replies/), there's no real point for me to maintain this extension. I've had requests from a couple of people not to nuke this repo since they'd still like to use this, so feel free to continue using it. Or not. It's really up to you. Here's a cactus :cactus: 
 
 # github-canned-responses
 


### PR DESCRIPTION
Hi, I googled "github canned responses", and only found links to your extension on the first page of results. When I saw your note in the README that this extension was superseded, it took me some more googling to find the GitHub _Saved replies_ feature.

To help other users find this Saved replies feature, I added a direct link to the README (also fixed the markdown title and added a few more lights for symmetry).

(instead of https://help.github.com/articles/working-with-saved-replies/, you could also link to https://github.com/blog/2135-saved-replies, but in my experience the GitHub blog entries tend to get out of date after a while, so it's probably better to link to the actually documentation)